### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "sun",
     "sun position"
   ],
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "iobroker-jsonexplorer": "0.1.12",


### PR DESCRIPTION
adapter core 3.x.x is known to fail during installation on node 14 as npm 6 does not install peer dependencies. So this adapter reuired node 16 or newer